### PR TITLE
Speed up pin manipulation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 pub mod sysfs;
 
 /// Value read from or written to a GPIO port.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum GpioValue {
     Low,
     High,


### PR DESCRIPTION
By storing the pin state in userspace, a syscall can be avoided if the requested state is equal to the current state.

In a real world application like [ledcat](https://github.com/polyfloyd/ledcat), this leads to a speed increase of about 400%.
